### PR TITLE
expand translation

### DIFF
--- a/src/components/vault/EntryDetails.js
+++ b/src/components/vault/EntryDetails.js
@@ -39,10 +39,18 @@ import { useTranslations } from '../../hooks/i18n';
 
 const ENTRY_ATTACHMENT_ATTRIB_PREFIX = Entry.Attributes.AttachmentPrefix;
 const FIELD_TYPE_OPTIONS = [
-  { type: EntryPropertyValueType.Text, title: 'text', icon: 'italic' },
-  { type: EntryPropertyValueType.Note, title: 'note', icon: 'align-left' },
-  { type: EntryPropertyValueType.Password, title: 'password', icon: 'key' },
-  { type: EntryPropertyValueType.OTP, title: 'otp', icon: 'time' }
+  { type: EntryPropertyValueType.Text, i18nKey: 'custom-fields.field-type.text', icon: 'italic' },
+  {
+    type: EntryPropertyValueType.Note,
+    i18nKey: 'custom-fields.field-type.note',
+    icon: 'align-left'
+  },
+  {
+    type: EntryPropertyValueType.Password,
+    i18nKey: 'custom-fields.field-type.password',
+    icon: 'key'
+  },
+  { type: EntryPropertyValueType.OTP, i18nKey: 'custom-fields.field-type.otp', icon: 'time' }
 ];
 
 function iconName(mimeType) {
@@ -592,7 +600,7 @@ const FieldRow = ({
       <For each="fieldTypeOption" of={FIELD_TYPE_OPTIONS}>
         <MenuItem
           key={fieldTypeOption.type}
-          text={t(`custom-fields.change-type.${fieldTypeOption.title}`)}
+          text={t('custom-fields.change-type') + t(fieldTypeOption.i18nKey)}
           icon={fieldTypeOption.icon}
           labelElement={
             field.valueType === fieldTypeOption.type ? <Icon icon="small-tick" /> : null

--- a/src/components/vault/EntryDetails.js
+++ b/src/components/vault/EntryDetails.js
@@ -600,7 +600,7 @@ const FieldRow = ({
       <For each="fieldTypeOption" of={FIELD_TYPE_OPTIONS}>
         <MenuItem
           key={fieldTypeOption.type}
-          text={`${t('custom-fields.change-type')}${t(fieldTypeOption.i18nKey)}`}
+          text={`${t('custom-fields.change-type')} ${t(fieldTypeOption.i18nKey)}`}
           icon={fieldTypeOption.icon}
           labelElement={
             field.valueType === fieldTypeOption.type ? <Icon icon="small-tick" /> : null

--- a/src/components/vault/EntryDetails.js
+++ b/src/components/vault/EntryDetails.js
@@ -39,10 +39,10 @@ import { useTranslations } from '../../hooks/i18n';
 
 const ENTRY_ATTACHMENT_ATTRIB_PREFIX = Entry.Attributes.AttachmentPrefix;
 const FIELD_TYPE_OPTIONS = [
-  { type: EntryPropertyValueType.Text, title: 'Text (default)', icon: 'italic' },
-  { type: EntryPropertyValueType.Note, title: 'Note', icon: 'align-left' },
-  { type: EntryPropertyValueType.Password, title: 'Password', icon: 'key' },
-  { type: EntryPropertyValueType.OTP, title: 'OTP', icon: 'time' }
+  { type: EntryPropertyValueType.Text, title: 'text', icon: 'italic' },
+  { type: EntryPropertyValueType.Note, title: 'note', icon: 'align-left' },
+  { type: EntryPropertyValueType.Password, title: 'password', icon: 'key' },
+  { type: EntryPropertyValueType.OTP, title: 'otp', icon: 'time' }
 ];
 
 function iconName(mimeType) {
@@ -285,7 +285,7 @@ const Attachments = ({
   return (
     <AttachmentsContainer>
       <If condition={attachments.length === 0}>
-        <AttachmentDropInstruction>Drag and drop to add attachments</AttachmentDropInstruction>
+        <AttachmentDropInstruction>{t('attachments.drop-instruction')}</AttachmentDropInstruction>
       </If>
       <For each="attachment" of={attachments}>
         <AttachmentItem
@@ -570,6 +570,7 @@ const FieldRow = ({
   onFieldSetValueType,
   onRemoveField
 }) => {
+  const t = useTranslations();
   const label =
     editing && field.removeable ? (
       <EditableText
@@ -591,7 +592,7 @@ const FieldRow = ({
       <For each="fieldTypeOption" of={FIELD_TYPE_OPTIONS}>
         <MenuItem
           key={fieldTypeOption.type}
-          text={`Change Type: ${fieldTypeOption.title}`}
+          text={t(`custom-fields.change-type.${fieldTypeOption.title}`)}
           icon={fieldTypeOption.icon}
           labelElement={
             field.valueType === fieldTypeOption.type ? <Icon icon="small-tick" /> : null
@@ -602,7 +603,11 @@ const FieldRow = ({
         />
       </For>
       <MenuDivider />
-      <MenuItem text="Delete Field" icon="trash" onClick={() => onRemoveField(field)} />
+      <MenuItem
+        text={t('custom-fields.delete-field')}
+        icon="trash"
+        onClick={() => onRemoveField(field)}
+      />
     </Menu>
   );
   return (

--- a/src/components/vault/EntryDetails.js
+++ b/src/components/vault/EntryDetails.js
@@ -600,7 +600,7 @@ const FieldRow = ({
       <For each="fieldTypeOption" of={FIELD_TYPE_OPTIONS}>
         <MenuItem
           key={fieldTypeOption.type}
-          text={t('custom-fields.change-type') + t(fieldTypeOption.i18nKey)}
+          text={`${t('custom-fields.change-type')}${t(fieldTypeOption.i18nKey)}`}
           icon={fieldTypeOption.icon}
           labelElement={
             field.valueType === fieldTypeOption.type ? <Icon icon="small-tick" /> : null

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -17,7 +17,7 @@
   },
   "cancel": "Cancel",
   "custom-fields": {
-    "change-type": "Change Type: ",
+    "change-type": "Change Type:",
     "delete-field": "Delete Field",
     "field-type": {
       "text": "Text (default)",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -5,7 +5,7 @@
       "cancel-title": "Cancel attachment deletion",
       "delete": "Delete",
       "delete-prompt": "Deleting this attachment will permanently remove it from your vault.\nAre you sure that you want to delete it?",
-      "delete-prompt-title": "Delte \"{{title}}\"",
+      "delete-prompt-title": "Delete \"{{title}}\"",
       "delete-title": "Confirm attachment deletion"
     },
     "delete": "Delete",
@@ -16,6 +16,16 @@
     "drop-instruction": "Drag and drop to add attachments"
   },
   "cancel": "Cancel",
+  "custom-fields": {
+    "change-type": "Change Type: ",
+    "delete-field": "Delete Field",
+    "field-type": {
+      "text": "Text (default)",
+      "note": "Note",
+      "password": "Password",
+      "otp": "Note"
+    }
+  },
   "entries-list": {
     "create-one-cta": "Why not create one?",
     "documents": "Documents",
@@ -48,15 +58,6 @@
       "trash-btn": "Move to Trash"
     },
     "untitled": "(Untitled)"
-  },
-  "custom-fields": {
-    "change-type": {
-      "text": "Change Type: Text (default)",
-      "note": "Change Type: Note",
-      "password": "Change Type: Password",
-      "otp": "Change Type: Note"
-    },
-    "delete-field": "Delete Field"
   },
   "entry-menu": {
     "move-to": "Move to...",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -12,7 +12,8 @@
     "delete-title": "Delete attachment",
     "download": "Download",
     "download-title": "Download attachment",
-    "drop-files": "Drop file(s) to add to vault"
+    "drop-files": "Drop file(s) to add to vault",
+    "drop-instruction": "Drag and drop to add attachments"
   },
   "cancel": "Cancel",
   "entries-list": {
@@ -47,6 +48,15 @@
       "trash-btn": "Move to Trash"
     },
     "untitled": "(Untitled)"
+  },
+  "custom-fields": {
+    "change-type": {
+      "text": "Change Type: Text (default)",
+      "note": "Change Type: Note",
+      "password": "Change Type: Password",
+      "otp": "Change Type: Note"
+    },
+    "delete-field": "Delete Field"
   },
   "entry-menu": {
     "move-to": "Move to...",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -16,6 +16,16 @@
     "drop-instruction": "ファイルをドロップして追加"
   },
   "cancel": "キャンセル",
+  "custom-fields": {
+    "change-type": "形式を変更: ",
+    "delete-field": "フィールドを削除",
+    "field-type": {
+      "text": "テキスト(デフォルト)",
+      "note": "ノート",
+      "password": "パスワード",
+      "otp": "OTP"
+    }
+  },
   "entries-list": {
     "create-one-cta": "ドキュメントを追加する",
     "documents": "ドキュメント",
@@ -48,15 +58,6 @@
       "trash-btn": "ゴミ箱に移動する"
     },
     "untitled": "(無題のドキュメント)"
-  },
-  "custom-fields": {
-    "change-type": {
-      "text": "形式を変更: テキスト(デフォルト)",
-      "note": "形式を変更: ノート",
-      "password": "形式を変更: パスワード",
-      "otp": "形式を変更: OTP"
-    },
-    "delete-field": "フィールドを削除"
   },
   "entry-menu": {
     "move-to": "移動する",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -12,7 +12,8 @@
     "delete-title": "ファイルを削除する",
     "download": "ダウンロード",
     "download-title": "ファイルをダウンロード",
-    "drop-files": "ファイルをドロップして追加"
+    "drop-files": "ファイルをドロップして追加",
+    "drop-instruction": "ファイルをドロップして追加"
   },
   "cancel": "キャンセル",
   "entries-list": {
@@ -47,6 +48,15 @@
       "trash-btn": "ゴミ箱に移動する"
     },
     "untitled": "(無題のドキュメント)"
+  },
+  "custom-fields": {
+    "change-type": {
+      "text": "形式を変更: テキスト(デフォルト)",
+      "note": "形式を変更: ノート",
+      "password": "形式を変更: パスワード",
+      "otp": "形式を変更: OTP"
+    },
+    "delete-field": "フィールドを削除"
   },
   "entry-menu": {
     "move-to": "移動する",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -17,7 +17,7 @@
   },
   "cancel": "キャンセル",
   "custom-fields": {
-    "change-type": "形式を変更: ",
+    "change-type": "形式を変更:",
     "delete-field": "フィールドを削除",
     "field-type": {
       "text": "テキスト(デフォルト)",


### PR DESCRIPTION
This PR depends on #38.
Expanding translation coverage for custom-field-type.
The implementation may evil as translation keys ain't hard coded and are generated with tagged template literals.
```
t(`custom-fields.change-type.${fieldTypeOption.title}`)
```