### PR TITLE
feat: add copy username and password shortcuts

### DIFF
--- a/src/components/vault/EntriesList.js
+++ b/src/components/vault/EntriesList.js
@@ -8,6 +8,7 @@ import { PaneContainer, PaneHeader, PaneContent, PaneFooter } from './Pane';
 import AddEntry from './AddEntry';
 import { VaultContext } from './Vault';
 import { useTranslations } from '../../hooks/i18n';
+import { copyToClipboard } from '../../utils';
 
 const EntriesList = ({ className }) => {
   const t = useTranslations();
@@ -26,7 +27,9 @@ const EntriesList = ({ className }) => {
   const keyMap = {
     arrowUp: 'up',
     arrowDown: 'down',
-    enter: 'enter'
+    enter: 'enter',
+    copyUsername: 'ctrl+b',
+    copyPassword: 'ctrl+c'
   };
   const handleNavigation = (event, step) => {
     event.preventDefault();
@@ -39,6 +42,13 @@ const EntriesList = ({ className }) => {
       ref.current.focus();
     }
   };
+  const handleCopyField = entryToCopy => {
+    if (!entryToCopy) {
+      return;
+    }
+
+    return copyToClipboard(entryToCopy.value);
+  };
   const handlers = {
     arrowUp: event => handleNavigation(event, -1),
     arrowDown: event => handleNavigation(event, 1),
@@ -46,7 +56,11 @@ const EntriesList = ({ className }) => {
       if (document.activeElement !== ref.current) {
         document.activeElement.click();
       }
-    }
+    },
+    copyUsername: () =>
+      handleCopyField(entries[currentIndex].fields.find(field => field.title === 'Username')),
+    copyPassword: () =>
+      handleCopyField(entries[currentIndex].fields.find(field => field.title === 'Password'))
   };
 
   return (


### PR DESCRIPTION
add 2 new keyboard shortcuts in the EntriesList component:

- `Ctrl+b` to copy the username of the current selected entry
- `Ctrl+c` to copy the password of the current selected entry

These shortcuts are triggered when the user select an entry. (if the
focus is elsewhere it is not available).

> **Note**: I cannot find any code relative to an existing shortcut (Ctrl+b) to copy the password

It resolve the issue on [buttercup desktop](https://github.com/buttercup/buttercup-desktop/issues/1041) about missing copy usernme or password shortcuts.